### PR TITLE
Update Nokogiri gem

### DIFF
--- a/creek.gemspec
+++ b/creek.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 2.13.0'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'nokogiri', '~> 1.7.0'
+  spec.add_dependency 'nokogiri', '~> 1.8.1'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
 end

--- a/lib/creek/version.rb
+++ b/lib/creek/version.rb
@@ -1,3 +1,3 @@
 module Creek
-  VERSION = '1.1.4'
+  VERSION = '1.1.5'
 end


### PR DESCRIPTION
This PR relates to https://jira.td-berlin.com/browse/PULSE-498 ticket.

Nokogiri versions prior to 1.8.1 are vulnerable http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050

To update Nokogiri version in **td_pulse** we have to resolve its dependencies: td_pulse -> excel_facts -> td_creek -> nokogiri (~> 1.7.0)